### PR TITLE
修复hangfire更新作业参数类型错误

### DIFF
--- a/FIX_SUMMARY.md
+++ b/FIX_SUMMARY.md
@@ -1,0 +1,77 @@
+# Hangfire Job Configuration Fix - PerformContext Parameter Handling
+
+## 问题描述
+
+在使用Hangfire.RecurringJobAdmin的Job Configuration页面修改定时作业时，即使没有任何更改，也会出现以下错误：
+
+```
+Arguments are not of specified type
+```
+
+这个问题出现的原因是：
+
+1. Hangfire会自动注入`PerformContext`等参数到作业方法中
+2. 这些参数在存储时通常为`null`值
+3. 当尝试更新作业时，代码试图将`null`转换为`PerformContext`类型，导致类型转换失败
+
+## 修复方案
+
+### 1. 后端修改（ChangeJobDispatcher.cs）
+
+- 添加了Hangfire自动注入参数类型的过滤列表
+- 在处理参数时跳过这些自动注入的参数类型
+- 改进了参数类型转换逻辑，正确处理null值
+
+```csharp
+// Hangfire自动注入的参数类型，这些参数不需要用户提供
+private static readonly HashSet<string> HangfireInjectedTypes = new HashSet<string>
+{
+    "Hangfire.Server.PerformContext",
+    "Hangfire.IJobCancellationToken",
+    "System.Threading.CancellationToken"
+};
+```
+
+### 2. 前端修改（JobExtensionPage.cshtml.cs）
+
+- 在获取作业数据时过滤掉Hangfire自动注入的参数
+- 确保前端显示的参数与用户实际需要配置的参数一致
+
+## 修复的核心逻辑
+
+1. **参数过滤**: 识别并过滤掉Hangfire自动注入的参数类型
+2. **类型验证**: 使用过滤后的参数进行类型验证和转换
+3. **方法查找**: 使用完整的参数类型列表（包括注入类型）查找方法
+4. **作业注册**: 使用过滤后的参数注册作业
+
+## 测试用例
+
+在`TestExecution.cs`中添加了测试方法：
+
+```csharp
+[RecurringJob("0 0 * * *", "Asia/Shanghai", "default", RecurringJobId = "DifyCleanTasks")]
+public void Execute(PerformContext context)
+{
+    Console.WriteLine($"DifyCleanTasks executed at {DateTime.Now}");
+    context?.WriteLine("Task completed successfully");
+}
+```
+
+这个方法现在应该能够在Job Configuration页面正常编辑而不出现错误。
+
+## 受影响的文件
+
+1. `src/Hangfire.RecurringJobAdmin/Pages/ChangeJobDispatcher.cs` - 后端参数处理逻辑
+2. `src/Hangfire.RecurringJobAdmin/Dashboard/Pages/JobExtensionPage.cshtml.cs` - 前端数据获取逻辑
+3. `samples/Hangfire.Sample/TestExecution.cs` - 测试用例
+
+## 兼容性
+
+这个修复向后兼容，不会影响现有的作业配置。对于不包含Hangfire注入参数的方法，行为保持不变。
+
+## 验证方法
+
+1. 启动示例应用
+2. 访问 `/hangfire/JobConfiguration` 页面
+3. 尝试编辑包含`PerformContext`参数的作业（如DifyCleanTasks）
+4. 即使不做任何更改也应该能够成功保存，不再出现"Arguments are not of specified type"错误

--- a/samples/Hangfire.Sample/TestExecution.cs
+++ b/samples/Hangfire.Sample/TestExecution.cs
@@ -1,4 +1,5 @@
-﻿using Hangfire.RecurringJobAdmin;
+using Hangfire.RecurringJobAdmin;
+using Hangfire.Server;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,6 +22,25 @@ namespace Hangfire.JobExtensions.DotNetCore.Test
         public void CheckFileExists()
         {
             Console.WriteLine("Check File Exists");
+        }
+
+        /// <summary>
+        /// 测试带有PerformContext参数的方法 - 这个方法应该能够在Job Configuration页面正常编辑而不报错
+        /// </summary>
+        [RecurringJob("0 0 * * *", "Asia/Shanghai", "default", RecurringJobId = "DifyCleanTasks")]
+        public void Execute(PerformContext context)
+        {
+            Console.WriteLine($"DifyCleanTasks executed at {DateTime.Now}");
+            context?.WriteLine("Task completed successfully");
+        }
+
+        /// <summary>
+        /// 测试带有其他参数加PerformContext的方法
+        /// </summary>
+        public void ExecuteWithParams(string message, int count, PerformContext context)
+        {
+            Console.WriteLine($"ExecuteWithParams: {message}, Count: {count}");
+            context?.WriteLine($"Processing {count} items with message: {message}");
         }
     }
 


### PR DESCRIPTION
Fix 'Arguments are not of specified type' error when updating Hangfire recurring jobs.

The error occurred because Hangfire automatically injects parameters like `PerformContext`, which are stored as `null`. The previous logic attempted to convert these `null` values to their respective types, leading to a type conversion error. This PR filters out these auto-injected parameters during argument processing and ensures `null` values are correctly handled for nullable types.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-278129b1-d7b9-43aa-90f6-5de947a9ffce) · [Cursor](https://cursor.com/background-agent?bcId=bc-278129b1-d7b9-43aa-90f6-5de947a9ffce)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)